### PR TITLE
check and reset prefs that do not have default values

### DIFF
--- a/src/privileged/multipreffer/api.js
+++ b/src/privileged/multipreffer/api.js
@@ -56,6 +56,7 @@ this.FirefoxHooks = {
       Preferences.get("extensions.multipreffer.test.variationName",
                       this.studyInfo.variation.name);
     const prefs = this.variations[variationName].prefs;
+    const nonDefaultPrefs = this.variations[variationName].prefs.nonDefault;
     if (this.studyInfo.isFirstRun) {
       for (const name of Object.keys(prefs.setValues)) {
         if (Preferences.isSet(name)) {
@@ -65,6 +66,17 @@ this.FirefoxHooks = {
           return;
         }
       }
+      for (const ndPref of nonDefaultPrefs) {
+        if (Preferences.get(ndPref.pref) !== ndPref.reset_to) {
+          // One of the prefs has an incorrect user-set value, ABORT!!!
+          // TODO: End the study/uninstall the addon?
+          Preferences.set(this.abortedPref, true);
+          return;
+        }
+      }
+    }
+    for (const ndPref of nonDefaultPrefs) {
+      Preferences.set(ndPref.pref, ndPref.value);
     }
     Preferences.set(prefs.setValues);
   },

--- a/src/privileged/multipreffer/api.js
+++ b/src/privileged/multipreffer/api.js
@@ -100,6 +100,20 @@ this.FirefoxHooks = {
         }
       }
       Preferences.set(resetValues);
+
+      // At this point, the category pref has been wiped; let's recompute it.
+      // BrowserGlue will recompute the category pref when the cookie behavior
+      // pref changes value, but only if the category pref is unset. So, we
+      // need to change the cookie behavior pref, which will recompute the
+      // category pref. Then, clear the newly recomputed category pref, and
+      // finally restore the cookie behavior pref again which will recompute
+      // the category pref in the correct state.
+      const cookieBehaviorValue =
+        Preferences.get("network.cookie.cookieBehavior");
+      const tempCookieBehaviorValue = cookieBehaviorValue === 4 ? 0 : 4;
+      Preferences.set("network.cookie.cookieBehavior", tempCookieBehaviorValue);
+      Preferences.reset("browser.contentblocking.category");
+      Preferences.set("network.cookie.cookieBehavior", cookieBehaviorValue);
     } catch (e) {
       Cu.reportError(e);
     }

--- a/src/privileged/multipreffer/api.js
+++ b/src/privileged/multipreffer/api.js
@@ -56,27 +56,15 @@ this.FirefoxHooks = {
       Preferences.get("extensions.multipreffer.test.variationName",
                       this.studyInfo.variation.name);
     const prefs = this.variations[variationName].prefs;
-    const nonDefaultPrefs = this.variations[variationName].prefs.nonDefault;
     if (this.studyInfo.isFirstRun) {
       for (const name of Object.keys(prefs.setValues)) {
-        if (Preferences.isSet(name)) {
+        if (!prefs.expectNonDefaults.includes(name) && Preferences.isSet(name)) {
           // One of the prefs has a user-set value, ABORT!!!
           // TODO: End the study/uninstall the addon?
           Preferences.set(this.abortedPref, true);
           return;
         }
       }
-      for (const ndPref of nonDefaultPrefs) {
-        if (Preferences.get(ndPref.pref) !== ndPref.reset_to) {
-          // One of the prefs has an incorrect user-set value, ABORT!!!
-          // TODO: End the study/uninstall the addon?
-          Preferences.set(this.abortedPref, true);
-          return;
-        }
-      }
-    }
-    for (const ndPref of nonDefaultPrefs) {
-      Preferences.set(ndPref.pref, ndPref.value);
     }
     Preferences.set(prefs.setValues);
   },

--- a/src/variations.json
+++ b/src/variations.json
@@ -4,21 +4,16 @@
     "prefs": {
       "setValues": {
         "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
-        "network.cookie.cookieBehavior": 0
+        "network.cookie.cookieBehavior": 0,
+        "browser.contentblocking.category": "custom"
       },
-      "nonDefault": [
-        {
-          "pref": "browser.contentblocking.category",
-          "value": "custom",
-          "reset_to": "standard"
-        }
-      ],
+      "expectNonDefaults": ["browser.contentblocking.category"],
       "resetDefaults": [
         "network.cookie.cookieBehavior",
-        "urlclassifier.trackingAnnotationTable"
+        "urlclassifier.trackingAnnotationTable",
+        "browser.contentblocking.category"
       ],
       "resetValues": {
-        "browser.contentblocking.category": "standard"
       }
     }
   },
@@ -28,21 +23,16 @@
     "prefs": {
       "setValues": {
         "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256,content-track-digest256",
-        "network.cookie.cookieBehavior": 4
+        "network.cookie.cookieBehavior": 4,
+        "browser.contentblocking.category": "custom"
       },
-      "nonDefault": [
-        {
-          "pref": "browser.contentblocking.category",
-          "value": "custom",
-          "reset_to": "standard"
-        }
-      ],
+      "expectNonDefaults": ["browser.contentblocking.category"],
       "resetDefaults": [
         "network.cookie.cookieBehavior",
-        "urlclassifier.trackingAnnotationTable"
+        "urlclassifier.trackingAnnotationTable",
+        "browser.contentblocking.category"
       ],
       "resetValues": {
-        "browser.contentblocking.category": "standard"
       }
     }
   }

--- a/src/variations.json
+++ b/src/variations.json
@@ -6,11 +6,19 @@
         "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
         "network.cookie.cookieBehavior": 0
       },
+      "nonDefault": [
+        {
+          "pref": "browser.contentblocking.category",
+          "value": "custom",
+          "reset_to": "standard"
+        }
+      ],
       "resetDefaults": [
         "network.cookie.cookieBehavior",
         "urlclassifier.trackingAnnotationTable"
       ],
       "resetValues": {
+        "browser.contentblocking.category": "standard"
       }
     }
   },
@@ -22,11 +30,19 @@
         "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256,content-track-digest256",
         "network.cookie.cookieBehavior": 4
       },
+      "nonDefault": [
+        {
+          "pref": "browser.contentblocking.category",
+          "value": "custom",
+          "reset_to": "standard"
+        }
+      ],
       "resetDefaults": [
         "network.cookie.cookieBehavior",
         "urlclassifier.trackingAnnotationTable"
       ],
       "resetValues": {
+        "browser.contentblocking.category": "standard"
       }
     }
   }

--- a/test/functional/all.js
+++ b/test/functional/all.js
@@ -85,16 +85,8 @@ describe("setup and teardown", function() {
       const prefs = variations[variation].prefs;
       const allPrefs = Object.keys(prefs.setValues);
 
-      const testPref = allPrefs[0];
-      const val = prefs.setValues[testPref];
-      let testVal;
-      if (typeof val === "number") {
-        testVal = 999;
-      } else if (typeof val === "string") {
-        testVal = "Test Value!";
-      } else if (typeof val === "boolean") {
-        testVal = true;
-      }
+      const testPref = "network.cookie.cookieBehavior";
+      const testVal = 3;
 
       describe(`sets the correct prefs for variation ${variation}`, () => {
         before(async () => {
@@ -108,7 +100,7 @@ describe("setup and teardown", function() {
         });
 
         it("has the correct prefs after uninstall", async () => {
-          await utils.setPreference(driver, allPrefs[0], testVal);
+          await utils.setPreference(driver, testPref, testVal);
           await utils.setupWebdriver.uninstallAddon(driver, addonId);
           const prefsToCheck = Object.assign({}, prefs.setValues);
           for (const pref of prefs.resetDefaults) {
@@ -118,7 +110,7 @@ describe("setup and teardown", function() {
             prefsToCheck[pref] = prefs.resetValues[pref];
           }
           prefsToCheck[testPref] = testVal;
-          prefsToCheck["browser.contentblocking.category"] = "standard";
+          prefsToCheck["browser.contentblocking.category"] = "custom";
           await checkPrefs(driver, allPrefs, prefsToCheck);
           for (const pref in prefsToCheck) {
             await utils.clearPreference(driver, pref);

--- a/test/functional/all.js
+++ b/test/functional/all.js
@@ -63,6 +63,7 @@ describe("setup and teardown", function() {
           for (const pref in prefs.resetValues) {
             prefsToCheck[pref] = prefs.resetValues[pref];
           }
+          prefsToCheck["browser.contentblocking.category"] = "standard";
           await checkPrefs(driver, allPrefs, prefsToCheck);
           for (const pref in prefsToCheck) {
             await utils.clearPreference(driver, pref);
@@ -85,7 +86,7 @@ describe("setup and teardown", function() {
       const allPrefs = Object.keys(prefs.setValues);
 
       const testPref = allPrefs[0];
-      let val = prefs.setValues[testPref];
+      const val = prefs.setValues[testPref];
       let testVal;
       if (typeof val === "number") {
         testVal = 999;
@@ -117,6 +118,7 @@ describe("setup and teardown", function() {
             prefsToCheck[pref] = prefs.resetValues[pref];
           }
           prefsToCheck[testPref] = testVal;
+          prefsToCheck["browser.contentblocking.category"] = "standard";
           await checkPrefs(driver, allPrefs, prefsToCheck);
           for (const pref in prefsToCheck) {
             await utils.clearPreference(driver, pref);
@@ -189,16 +191,8 @@ describe("setup and teardown", function() {
       }
       const allPrefs = Object.keys(prefs.setValues);
 
-      const testPref = prefs.expectNonDefaults[0];
-      const val = prefs.setValues[testPref];
-      let testVal;
-      if (typeof val === "number") {
-        testVal = 999;
-      } else if (typeof val === "string") {
-        testVal = "Test Value!";
-      } else if (typeof val === "boolean") {
-        testVal = true;
-      }
+      const testPref = "browser.contentblocking.category";
+      const testVal = "standard";
 
       describe(`sets the correct prefs for ${variation}`, () => {
         before(async () => {
@@ -221,6 +215,7 @@ describe("setup and teardown", function() {
           for (const pref in prefs.resetValues) {
             prefsToCheck[pref] = prefs.resetValues[pref];
           }
+          prefsToCheck["browser.contentblocking.category"] = "standard";
           await checkPrefs(driver, allPrefs, prefsToCheck);
           for (const pref in prefsToCheck) {
             await utils.clearPreference(driver, pref);

--- a/test/functional/all.js
+++ b/test/functional/all.js
@@ -83,6 +83,18 @@ describe("setup and teardown", function() {
     for (const variation in variations) {
       const prefs = variations[variation].prefs;
       const allPrefs = Object.keys(prefs.setValues);
+
+      const testPref = allPrefs[0];
+      let val = prefs.setValues[testPref];
+      let testVal;
+      if (typeof val === "number") {
+        testVal = 999;
+      } else if (typeof val === "string") {
+        testVal = "Test Value!";
+      } else if (typeof val === "boolean") {
+        testVal = true;
+      }
+
       describe(`sets the correct prefs for variation ${variation}`, () => {
         before(async () => {
           await utils.setPreference(driver, "extensions.multipreffer.test.variationName", variation);
@@ -95,7 +107,7 @@ describe("setup and teardown", function() {
         });
 
         it("has the correct prefs after uninstall", async () => {
-          await utils.setPreference(driver, allPrefs[0], "TEST VALUE!!");
+          await utils.setPreference(driver, allPrefs[0], testVal);
           await utils.setupWebdriver.uninstallAddon(driver, addonId);
           const prefsToCheck = Object.assign({}, prefs.setValues);
           for (const pref of prefs.resetDefaults) {
@@ -104,7 +116,7 @@ describe("setup and teardown", function() {
           for (const pref in prefs.resetValues) {
             prefsToCheck[pref] = prefs.resetValues[pref];
           }
-          prefsToCheck[allPrefs[0]] = "TEST VALUE!!";
+          prefsToCheck[testPref] = testVal;
           await checkPrefs(driver, allPrefs, prefsToCheck);
           for (const pref in prefsToCheck) {
             await utils.clearPreference(driver, pref);
@@ -118,7 +130,7 @@ describe("setup and teardown", function() {
     }
   });
 
-  describe("Set some user prefs, ensure addon doesn't do anything", function() {
+  describe("Set up some prefs with unexpected values, ensure addon doesn't do anything", function() {
     const SETUP_DELAY = 500;
     let addonId;
     let abortedPref;
@@ -126,10 +138,14 @@ describe("setup and teardown", function() {
     for (const variation in variations) {
       const prefs = variations[variation].prefs;
       const allPrefs = Object.keys(prefs.setValues);
+
+      const testPref = allPrefs[0];
+      const testVal = "Test Value!";
+
       describe(`no prefs should be set for ${variation}`, () => {
         before(async () => {
           await utils.setPreference(driver, "extensions.multipreffer.test.variationName", variation);
-          await utils.setPreference(driver, allPrefs[0], "TEST VALUE!!");
+          await utils.setPreference(driver, testPref, testVal);
           addonId = await utils.setupWebdriver.installAddon(driver);
           abortedPref = `extensions.multipreffer.${addonId}.aborted`;
           await driver.sleep(SETUP_DELAY);
@@ -139,7 +155,7 @@ describe("setup and teardown", function() {
           // Take the first of the target prefs and set it to some value
           // before installing the addon.
           const prefsToCheck = {};
-          prefsToCheck[allPrefs[0]] = "TEST VALUE!!";
+          prefsToCheck[testPref] = testVal;
           // The addon should set this pref to indicate that it aborted.
           allPrefs.push(abortedPref);
           prefsToCheck[abortedPref] = true;
@@ -148,10 +164,67 @@ describe("setup and teardown", function() {
 
         it("has the correct prefs after uninstall", async () => {
           const prefsToCheck = {};
-          prefsToCheck[allPrefs[0]] = "TEST VALUE!!";
+          prefsToCheck[testPref] = testVal;
           allPrefs.push(abortedPref);
           await utils.setupWebdriver.uninstallAddon(driver, addonId);
           await checkPrefs(driver, allPrefs, prefsToCheck);
+        });
+
+        after(async () => {
+          await utils.clearPreference(driver, testPref);
+          await utils.clearPreference(driver, "extensions.multipreffer.test.variationName");
+        });
+      });
+    }
+  });
+
+  describe("Ensure expectNonDefaults works", function() {
+    const SETUP_DELAY = 500;
+    let addonId;
+
+    for (const variation in variations) {
+      const prefs = variations[variation].prefs;
+      if (!prefs.expectNonDefaults.length) {
+        continue;
+      }
+      const allPrefs = Object.keys(prefs.setValues);
+
+      const testPref = prefs.expectNonDefaults[0];
+      const val = prefs.setValues[testPref];
+      let testVal;
+      if (typeof val === "number") {
+        testVal = 999;
+      } else if (typeof val === "string") {
+        testVal = "Test Value!";
+      } else if (typeof val === "boolean") {
+        testVal = true;
+      }
+
+      describe(`sets the correct prefs for ${variation}`, () => {
+        before(async () => {
+          await utils.setPreference(driver, "extensions.multipreffer.test.variationName", variation);
+          await utils.setPreference(driver, testPref, testVal);
+          addonId = await utils.setupWebdriver.installAddon(driver);
+          await driver.sleep(SETUP_DELAY);
+        });
+
+        it("has the correct prefs after install", async () => {
+          await checkPrefs(driver, allPrefs, prefs.setValues);
+        });
+
+        it("has the correct prefs after uninstall", async () => {
+          await utils.setupWebdriver.uninstallAddon(driver, addonId);
+          const prefsToCheck = Object.assign({}, prefs.setValues);
+          for (const pref of prefs.resetDefaults) {
+            prefsToCheck[pref] = undefined;
+          }
+          for (const pref in prefs.resetValues) {
+            prefsToCheck[pref] = prefs.resetValues[pref];
+          }
+          await checkPrefs(driver, allPrefs, prefsToCheck);
+          for (const pref in prefsToCheck) {
+            await utils.clearPreference(driver, pref);
+          }
         });
 
         after(async () => {


### PR DESCRIPTION
To see the need for this:
- start your browser
- go to about:preferences and click on "privacy & security", observe the category the user is in ("standard").
- Install the addon in the experiment branch, 
- you will see the category change to "custom"
- uninstall the addon
- the user is not reset to the "standard" category

This adds the ability to change a pref that has a non-default value set, and reset it to that value upon ending. 
This also adds the pref "browser.contentblocking.category", and requires it to be "standard" initially, "custom" get set throughout the test, then it will set back to "standard" when finished.
Another option could be to use the existing "resetValues" attribute, and check that the pref matches that on installing?

By requiring the user to be in "standard" on startup, we are essentially adding a requirement that they have TP also set to default in order to enroll, is there any problem with this? This pref is harmless and only changes the UI in about:preferences, however in the experiment branch, by changing the cookieBehavior pref it will automatically become "custom" in the interest of keeping both UI experiences as close as possible to the control branch, they should both change to "custom".

side note: can you add the requirement "browser.contentblocking.category" = "standard" to experimenter if it is not already?
