### PR TITLE
Upgrade to new default-prefs multipreffer, recompute category pref at init as well as cleanup.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cookie-restrictions-strict-list-study",
   "description": "A study that blocks tracking cookies from the strict list and the basic list, in two separate cohorts.",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "author": "Mozilla",
   "bugs": {
     "url": ""
@@ -49,7 +49,7 @@
     "prewatch": "npm run bundle-utils",
     "sign": "echo 'TBD'",
     "start": "web-ext run --no-reload",
-    "test": "ADDON_ZIP=./dist/cookie_restrictions_strict_list_study-1.1.zip mocha test/functional/ --bail",
+    "test": "ADDON_ZIP=./dist/cookie_restrictions_strict_list_study-2.0.zip mocha test/functional/ --bail",
     "watch": "web-ext run"
   }
 }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Cookie Restrictions Strict List Study",
-  "version": "1.4",
+  "version": "2.0",
   "description": "A study that blocks tracking cookies from the strict list and the basic list, in two separate cohorts.",
   "hidden": true,
   "background": {
@@ -10,7 +10,7 @@
   "applications": {
     "gecko": {
       "id": "cookie-restrictions-strict-list-study@shield.mozilla.org",
-      "strict_min_version": "65.0"
+      "strict_min_version": "66.0"
     }
   },
 

--- a/src/privileged/multipreffer/api.js
+++ b/src/privileged/multipreffer/api.js
@@ -10,16 +10,14 @@ ChromeUtils.defineModuleGetter(this, "AddonManager",
   "resource://gre/modules/AddonManager.jsm");
 ChromeUtils.defineModuleGetter(this, "Preferences",
   "resource://gre/modules/Preferences.jsm");
-ChromeUtils.defineModuleGetter(this, "AddonStudies",
-  "resource://normandy/lib/AddonStudies.jsm");
+const DefaultPreferences = new Preferences({ defaultBranch: true });
+
 
 let gExtension;
 
 this.multipreffer = class extends ExtensionAPI {
   getAPI(context) {
     gExtension = context.extension;
-    FirefoxHooks.init();
-
     return {
       multipreffer: {
         async studyReady(studyInfo) {
@@ -31,24 +29,9 @@ this.multipreffer = class extends ExtensionAPI {
 };
 
 this.FirefoxHooks = {
-  init() {
-    AddonStudies.addUnenrollListener(gExtension.id, async (reason) => {
-      await this.cleanup();
-    });
-    AddonManager.addAddonListener(this);
-  },
-
-  get abortedPref() {
-    return `extensions.multipreffer.${gExtension.id}.aborted`;
-  },
-
+  _oldDefaultValues: {},
   async studyReady(studyInfo) {
     // Called every time the add-on is loaded.
-    this.studyInfo = studyInfo;
-    if (Preferences.get(this.abortedPref)) {
-      return;
-    }
-
     try {
       const res = await fetch(gExtension.getURL("variations.json"));
       this.variations = await res.json();
@@ -58,75 +41,46 @@ this.FirefoxHooks = {
     }
 
     const variationName =
-      Preferences.get("extensions.multipreffer.test.variationName",
-                      this.studyInfo.variation.name);
+      Preferences.get(
+        "extensions.multipreffer.test.variationName", studyInfo.variation.name);
     const prefs = this.variations[variationName].prefs;
-    if (this.studyInfo.isFirstRun) {
-      for (const name of Object.keys(prefs.setValues)) {
-        if (!prefs.expectNonDefaults.includes(name) && Preferences.isSet(name)) {
-          // One of the prefs has a user-set value, ABORT!!!
-          // TODO: End the study/uninstall the addon?
-          Preferences.set(this.abortedPref, true);
-          return;
-        }
+
+    for (const pref of Object.keys(prefs)) {
+      let val = Preferences.get(pref);
+      if (val === undefined) {
+        // If undefined, save it as an empty string.
+        // This is the best we can do to reset it at cleanup
+        // since there's no way to clear the value of a pref
+        // on the default branch.
+        val = "";
       }
+      this._oldDefaultValues[pref] = val;
     }
-    Preferences.set(prefs.setValues);
+
+    DefaultPreferences.set(prefs);
+    this.recomputeCategoryPref();
+    AddonManager.addAddonListener(this);
   },
 
-  async cleanup() {
-    // Only run once. cleanup may get called from multiple listeners on expiry.
-    if (this._cleanedUp) {
-      return;
-    }
+  cleanup() {
     // Called when the add-on is being removed for any reason.
-    if (Preferences.get(this.abortedPref)) {
-      Preferences.reset(this.abortedPref);
-      return;
-    }
+    DefaultPreferences.set(this._oldDefaultValues);
+    this.recomputeCategoryPref();
+  },
 
-    try {
-      const variationName = Preferences.get("extensions.multipreffer.test.variationName", this.studyInfo.variation.name);
-      const prefs = this.variations[variationName].prefs;
-      const setValues = prefs.setValues;
-
-      // Handle the prefs that need to be reset to default.
-      const resetDefaults = [];
-      for (const pref of prefs.resetDefaults) {
-        if (Preferences.get(pref) === setValues[pref]) {
-          // Pref value hasn't changed from what we set. Include it.
-          resetDefaults.push(pref);
-        }
-      }
-      Preferences.reset(resetDefaults);
-
-      // Handle the prefs that need to be set to a specified value.
-      const resetValues = prefs.resetValues;
-      for (const [name, value] of Object.entries(setValues)) {
-        if (Preferences.get(name) !== value) {
-          // Pref was modified. Make sure it's not in the resetValues list.
-          delete resetValues[name];
-        }
-      }
-      Preferences.set(resetValues);
-
-      // At this point, the category pref has been wiped; let's recompute it.
-      // BrowserGlue will recompute the category pref when the cookie behavior
-      // pref changes value, but only if the category pref is unset. So, we
-      // need to change the cookie behavior pref, which will recompute the
-      // category pref. Then, clear the newly recomputed category pref, and
-      // finally restore the cookie behavior pref again which will recompute
-      // the category pref in the correct state.
-      const cookieBehaviorValue =
-        Preferences.get("network.cookie.cookieBehavior");
-      const tempCookieBehaviorValue = cookieBehaviorValue === 4 ? 0 : 4;
-      Preferences.set("network.cookie.cookieBehavior", tempCookieBehaviorValue);
-      Preferences.reset("browser.contentblocking.category");
-      Preferences.set("network.cookie.cookieBehavior", cookieBehaviorValue);
-      this._cleanedUp = true;
-    } catch (e) {
-      Cu.reportError(e);
-    }
+  recomputeCategoryPref() {
+    // BrowserGlue will recompute the category pref when the cookie behavior
+    // pref changes value, but only if the category pref is unset. So, we
+    // need to change the cookie behavior pref, which will recompute the
+    // category pref. Then, clear the newly recomputed category pref, and
+    // finally restore the cookie behavior pref again which will recompute
+    // the category pref in the correct state.
+    const cookieBehaviorValue =
+      Preferences.get("network.cookie.cookieBehavior");
+    const tempCookieBehaviorValue = cookieBehaviorValue === 4 ? 0 : 4;
+    Preferences.set("network.cookie.cookieBehavior", tempCookieBehaviorValue);
+    Preferences.reset("browser.contentblocking.category");
+    Preferences.set("network.cookie.cookieBehavior", cookieBehaviorValue);
   },
 
   onUninstalling(addon) {
@@ -141,7 +95,7 @@ this.FirefoxHooks = {
     if (addon.id !== gExtension.id) {
       return;
     }
-    await this.cleanup();
+    this.cleanup();
     AddonManager.removeAddonListener(this);
     // This is needed even for onUninstalling, because it nukes the addon
     // from UI. If we don't do this, the user has a chance to "undo".

--- a/src/variations.json
+++ b/src/variations.json
@@ -2,38 +2,16 @@
   "Control": {
     "weight": 1,
     "prefs": {
-      "setValues": {
-        "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
-        "network.cookie.cookieBehavior": 0,
-        "browser.contentblocking.category": "custom"
-      },
-      "expectNonDefaults": ["browser.contentblocking.category"],
-      "resetDefaults": [
-        "network.cookie.cookieBehavior",
-        "urlclassifier.trackingAnnotationTable",
-        "browser.contentblocking.category"
-      ],
-      "resetValues": {
-      }
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
+      "network.cookie.cookieBehavior": 0
     }
   },
 
   "Experiment": {
     "weight": 1,
     "prefs": {
-      "setValues": {
-        "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256,content-track-digest256",
-        "network.cookie.cookieBehavior": 4,
-        "browser.contentblocking.category": "custom"
-      },
-      "expectNonDefaults": ["browser.contentblocking.category"],
-      "resetDefaults": [
-        "network.cookie.cookieBehavior",
-        "urlclassifier.trackingAnnotationTable",
-        "browser.contentblocking.category"
-      ],
-      "resetValues": {
-      }
+      "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256,content-track-digest256",
+      "network.cookie.cookieBehavior": 4
     }
   }
 }


### PR DESCRIPTION
Based on everything I've learned about default prefs, etc in the last weeks, I refactored multipreffer to only support setting default-branch prefs. This simplifies testing as well as cleanup, and also is a much better way to do experiments (since it better represents "real world"). The limitation is that consumers that try to access these pref values before multipreffer gets initialized can't be supported. I think this is reasonable.

I also refactored this add-on to use the new multipreffer, and to force browserglue to compute the category pref both at init and cleanup - again, this I think makes the category pref take on a "real world" representative value.

If we still want to set it to "custom" during the experiment, we can do that, no problem - but I think that if we do, it needs to be paired with an assertion `the new values we are testing are not going to be considered "standard" - they are indeed going to be considered "custom"`.