### PR TITLE
Port updated tests for default-branch multipreffer from the search volume study

### DIFF
--- a/src/variations.json
+++ b/src/variations.json
@@ -1,5 +1,5 @@
 {
-  "Control": {
+  "control": {
     "weight": 1,
     "prefs": {
       "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256",
@@ -7,7 +7,7 @@
     }
   },
 
-  "Experiment": {
+  "treatment": {
     "weight": 1,
     "prefs": {
       "urlclassifier.trackingAnnotationTable": "test-track-simple,base-track-digest256,content-track-digest256",

--- a/test/functional/all.js
+++ b/test/functional/all.js
@@ -8,214 +8,86 @@ const utils = require("./utils");
 const variations = require("../../src/variations.json");
 
 async function checkPrefs(driver, allPrefs, prefs) {
-  for (const pref of allPrefs) {
+  for (const pref of Object.keys(allPrefs)) {
     if (prefs[pref] !== undefined) {
       const val = await utils.getPreference(driver, pref);
       assert.equal(val, prefs[pref], `set the right pref for ${pref}`);
     } else {
-      const hasUserValue = await utils.prefHasUserValue(driver, pref);
-      assert.isFalse(hasUserValue, `${pref} is set to the default`);
+      const val = await utils.getPreference(driver, pref);
+      assert.equal(val, allPrefs[pref], `set the right pref for ${pref}`);
     }
   }
 }
 
 describe("setup and teardown", function() {
+  const SETUP_DELAY = 1000;
+  const RESTART_DELAY = 2000;
   // This gives Firefox time to start, and us a bit longer during some of the tests.
-  this.timeout(15000);
+  this.timeout(30000);
 
   let driver;
 
-  // runs ONCE
-  before(async () => {
-    driver = await utils.setupWebdriver.promiseSetupDriver(
-      utils.FIREFOX_PREFERENCES,
-    );
-  });
-
-  after(() => {
-    driver.quit();
-  });
-
   describe("sets up the correct prefs, depending on the variation", function() {
-    const SETUP_DELAY = 500;
     let addonId;
 
     for (const variation in variations) {
       const prefs = variations[variation].prefs;
-      const allPrefs = Object.keys(prefs.setValues);
+      let allPrefs = {};
       describe(`sets the correct prefs for variation ${variation}`, () => {
         before(async () => {
+          driver = await utils.setupWebdriver.promiseSetupDriver(
+            utils.FIREFOX_PREFERENCES,
+          );
           await utils.setPreference(driver, "extensions.multipreffer.test.variationName", variation);
-          addonId = await utils.setupWebdriver.installAddon(driver);
+          allPrefs = {};
+          for (const pref of Object.keys(prefs)) {
+            // If the pref doesn't exist, utils.getPreference will return null.
+            // I think this is because the result of `await driver.executeScript`
+            // converts an explicit return value of `undefined` to null.
+            // This information is important later in our post-uninstall test.
+            allPrefs[pref] = await utils.getPreference(driver, pref);
+          }
+          addonId = await utils.installAddon(driver);
           await driver.sleep(SETUP_DELAY);
         });
 
         it("has the correct prefs after install", async () => {
-          await checkPrefs(driver, allPrefs, prefs.setValues);
+          await checkPrefs(driver, allPrefs, prefs);
+        });
+
+        it("has the correct prefs after restart", async () => {
+          driver = await utils.restartDriverWithSameProfile(driver);
+          await driver.sleep(RESTART_DELAY);
+          await checkPrefs(driver, allPrefs, prefs);
         });
 
         it("has the correct prefs after uninstall", async () => {
-          await utils.setupWebdriver.uninstallAddon(driver, addonId);
-          const prefsToCheck = Object.assign({}, prefs.setValues);
-          for (const pref of prefs.resetDefaults) {
-            prefsToCheck[pref] = undefined;
-          }
-          for (const pref in prefs.resetValues) {
-            prefsToCheck[pref] = prefs.resetValues[pref];
-          }
-          prefsToCheck["browser.contentblocking.category"] = "standard";
-          await checkPrefs(driver, allPrefs, prefsToCheck);
-          for (const pref in prefsToCheck) {
-            await utils.clearPreference(driver, pref);
-          }
-        });
-
-        after(async () => {
-          await utils.clearPreference(driver, "extensions.multipreffer.test.variationName");
-        });
-      });
-    }
-  });
-
-  describe("Check whether prefs user-modified after install are left user-modified after cleanup", function() {
-    const SETUP_DELAY = 500;
-    let addonId;
-
-    for (const variation in variations) {
-      const prefs = variations[variation].prefs;
-      const allPrefs = Object.keys(prefs.setValues);
-
-      const testPref = "network.cookie.cookieBehavior";
-      const testVal = 3;
-
-      describe(`sets the correct prefs for variation ${variation}`, () => {
-        before(async () => {
-          await utils.setPreference(driver, "extensions.multipreffer.test.variationName", variation);
-          addonId = await utils.setupWebdriver.installAddon(driver);
+          await utils.uninstallAddon(driver, addonId);
           await driver.sleep(SETUP_DELAY);
-        });
-
-        it("has the correct prefs after install", async () => {
-          await checkPrefs(driver, allPrefs, prefs.setValues);
-        });
-
-        it("has the correct prefs after uninstall", async () => {
-          await utils.setPreference(driver, testPref, testVal);
-          await utils.setupWebdriver.uninstallAddon(driver, addonId);
-          const prefsToCheck = Object.assign({}, prefs.setValues);
-          for (const pref of prefs.resetDefaults) {
-            prefsToCheck[pref] = undefined;
+          // It's not possible to remove default branch prefs from
+          // existence at runtime after they have a value, so
+          // multipreffer does the best it can at cleanup and sets
+          // an empty string value. So we need to expect this.
+          for (const pref of Object.keys(allPrefs)) {
+            if (allPrefs[pref] === null) {
+              switch (typeof prefs[pref]) {
+                case "string":
+                  allPrefs[pref] = "";
+                  break;
+                case "boolean":
+                  allPrefs[pref] = false;
+                  break;
+                case "number":
+                  allPrefs[pref] = 0;
+                  break;
+              }
+            }
           }
-          for (const pref in prefs.resetValues) {
-            prefsToCheck[pref] = prefs.resetValues[pref];
-          }
-          prefsToCheck[testPref] = testVal;
-          prefsToCheck["browser.contentblocking.category"] = "custom";
-          await checkPrefs(driver, allPrefs, prefsToCheck);
-          for (const pref in prefsToCheck) {
-            await utils.clearPreference(driver, pref);
-          }
+          await checkPrefs(driver, allPrefs, {});
         });
 
         after(async () => {
-          await utils.clearPreference(driver, "extensions.multipreffer.test.variationName");
-        });
-      });
-    }
-  });
-
-  describe("Set up some prefs with unexpected values, ensure addon doesn't do anything", function() {
-    const SETUP_DELAY = 500;
-    let addonId;
-    let abortedPref;
-
-    for (const variation in variations) {
-      const prefs = variations[variation].prefs;
-      const allPrefs = Object.keys(prefs.setValues);
-
-      const testPref = allPrefs[0];
-      const testVal = "Test Value!";
-
-      describe(`no prefs should be set for ${variation}`, () => {
-        before(async () => {
-          await utils.setPreference(driver, "extensions.multipreffer.test.variationName", variation);
-          await utils.setPreference(driver, testPref, testVal);
-          addonId = await utils.setupWebdriver.installAddon(driver);
-          abortedPref = `extensions.multipreffer.${addonId}.aborted`;
-          await driver.sleep(SETUP_DELAY);
-        });
-
-        it("has the correct prefs after install", async () => {
-          // Take the first of the target prefs and set it to some value
-          // before installing the addon.
-          const prefsToCheck = {};
-          prefsToCheck[testPref] = testVal;
-          // The addon should set this pref to indicate that it aborted.
-          allPrefs.push(abortedPref);
-          prefsToCheck[abortedPref] = true;
-          await checkPrefs(driver, allPrefs, prefsToCheck);
-        });
-
-        it("has the correct prefs after uninstall", async () => {
-          const prefsToCheck = {};
-          prefsToCheck[testPref] = testVal;
-          allPrefs.push(abortedPref);
-          await utils.setupWebdriver.uninstallAddon(driver, addonId);
-          await checkPrefs(driver, allPrefs, prefsToCheck);
-        });
-
-        after(async () => {
-          await utils.clearPreference(driver, testPref);
-          await utils.clearPreference(driver, "extensions.multipreffer.test.variationName");
-        });
-      });
-    }
-  });
-
-  describe("Ensure expectNonDefaults works", function() {
-    const SETUP_DELAY = 500;
-    let addonId;
-
-    for (const variation in variations) {
-      const prefs = variations[variation].prefs;
-      if (!prefs.expectNonDefaults.length) {
-        continue;
-      }
-      const allPrefs = Object.keys(prefs.setValues);
-
-      const testPref = "browser.contentblocking.category";
-      const testVal = "standard";
-
-      describe(`sets the correct prefs for ${variation}`, () => {
-        before(async () => {
-          await utils.setPreference(driver, "extensions.multipreffer.test.variationName", variation);
-          await utils.setPreference(driver, testPref, testVal);
-          addonId = await utils.setupWebdriver.installAddon(driver);
-          await driver.sleep(SETUP_DELAY);
-        });
-
-        it("has the correct prefs after install", async () => {
-          await checkPrefs(driver, allPrefs, prefs.setValues);
-        });
-
-        it("has the correct prefs after uninstall", async () => {
-          await utils.setupWebdriver.uninstallAddon(driver, addonId);
-          const prefsToCheck = Object.assign({}, prefs.setValues);
-          for (const pref of prefs.resetDefaults) {
-            prefsToCheck[pref] = undefined;
-          }
-          for (const pref in prefs.resetValues) {
-            prefsToCheck[pref] = prefs.resetValues[pref];
-          }
-          prefsToCheck["browser.contentblocking.category"] = "standard";
-          await checkPrefs(driver, allPrefs, prefsToCheck);
-          for (const pref in prefsToCheck) {
-            await utils.clearPreference(driver, pref);
-          }
-        });
-
-        after(async () => {
-          await utils.clearPreference(driver, "extensions.multipreffer.test.variationName");
+          await driver.quit();
         });
       });
     }


### PR DESCRIPTION
This is literally a copy-paste of the tests folder in etp-search-volume-study, which has updated tests for the default-branch version of multipreffer. The tests pass on this repo.